### PR TITLE
Fix: Resolve TS duplicate identifier and refine header styles

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,5 +1,3 @@
-import { Component } from '@angular/core';
-
 import { Component, HostListener } from '@angular/core';
 
 @Component({

--- a/src/app/header/header.css
+++ b/src/app/header/header.css
@@ -92,6 +92,7 @@
 .nav-links li {
   display: flex; /* To align 'a' tags vertically if needed */
   align-items: center; /* Vertically center 'a' tags */
+  height: 100%; /* Ensure li takes full height */
 }
 
 .nav-links a { /* These are the actual links */

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,3 +28,8 @@ a {
 a:hover {
   /* text-decoration: underline; */ /* Removing global underline for cleaner component-level control */
 }
+
+/* TEMPORARY: For testing scroll effects */
+body {
+  min-height: 150vh;
+}


### PR DESCRIPTION
- Fixed TS2300 error in header.component.ts by consolidating duplicate Component imports.
- Adjusted CSS for .nav-links li to include height: 100% to ensure correct positioning of the navigation link underline animation. The animation should now appear directly under each link text.
- Added temporary min-height to body in styles.css to enable page scrolling for testing header scroll effects.