### PR TITLE
Fix: Resolve duplicate Component import in CoreFeaturesComponent

### DIFF
--- a/src/app/core-features/core-features.component.ts
+++ b/src/app/core-features/core-features.component.ts
@@ -1,5 +1,3 @@
-import { Component } from '@angular/core';
-
 import { Component, OnInit, AfterViewInit, ElementRef, QueryList, ViewChildren } from '@angular/core';
 
 interface Feature {


### PR DESCRIPTION
Corrected a TypeScript error (TS2300) in core-features.component.ts by consolidating duplicate imports of 'Component' from '@angular/core' into a single import statement.