### PR TITLE
Fix: Correct class binding in core-features.html to resolve NG5002 error

### DIFF
--- a/src/app/core-features/core-features.html
+++ b/src/app/core-features/core-features.html
@@ -11,7 +11,7 @@
       <div *ngFor="let feature of features; let i = index" class="mb-4"> {/* mb-4 for spacing between cards */}
         <div class="feature-card h-100" #featureCard [style.transition-delay]="i * 100 + 'ms'">
           <div class="feature-card-icon-wrapper mb-3"> {/* Wrapper for icon if needed for alignment */}
-            <i class="{{ feature.iconPlaceholder }} feature-card-icon-element"></i>
+            <i [class]="feature.iconPlaceholder + ' feature-card-icon-element'"></i>
           </div>
           <h4 class="feature-card-title mb-2">{{ feature.title }}</h4>
           <p class="feature-card-description">{{ feature.description }}</p>


### PR DESCRIPTION
Changed the class binding for Bootstrap Icons in the Core Features section template from string interpolation to property binding `[class]` to prevent ICU message parsing errors (NG5002).

Old: <i class="{{ feature.iconPlaceholder }} feature-card-icon-element"></i>
New: <i [class]="feature.iconPlaceholder + ' feature-card-icon-element'"></i>